### PR TITLE
Automatically load dependent modules

### DIFF
--- a/build_functions.sh
+++ b/build_functions.sh
@@ -219,7 +219,7 @@ module_capture_prereq () {
 			# so we skip this dependency.
 			continue;
 		fi
-		echo -n "prereq $dep\\n"
+		echo -n "module load $dep\\n"
 	done
 }
 


### PR DESCRIPTION
This would automatically load module files, instead of producing a warning as mentioned in #5
```
Lmod has detected the following error: Cannot load module "...".
At least one of these module(s) must be loaded: ...
```
