### PR TITLE
Change MODULEPATH suggestion

### DIFF
--- a/build_functions.sh
+++ b/build_functions.sh
@@ -271,7 +271,7 @@ module_install () {
 		if ! echo "${MODULEPATH:-}" | grep "${MODULE_INSTALL_PATH}" >/dev/null; then
 			log_info ">>>"
 			log_info ">>> Info: MODULE_INSTALL_PATH is not in your MODULEPATH"
-			log_info ">>>       You may want to add a line like the following your startup"
+			log_info ">>>       You may want to add a line like the following to your startup"
 			log_info ">>>       scripts like ~/.bashrc:"
 			log_info ">>>"
 			log_info ">>>       export MODULEPATH=${MODULE_INSTALL_PATH}:\$MODULEPATH"


### PR DESCRIPTION
This fixes #24 by changing the message at the end of a package install. Currently the suggestion does not handle the case correctly where `$MODULEPATH` is empty. It would append an empty element, since it unconditionally adds a colon. The correct suggestion may confuse many users, though...
```bash
export MODULEPATH=${MODULE_INSTALL_PATH}\${MODULEPATH:+:\$MODULEPATH}"
```
Alternatively this could of course be handled with an `if`, but that would make the whole statement pretty ugly. The suggestion depends on many things in the users `.bashrc`, so the best solution for the user is unknown to Builder anyway.