### PR TITLE
Fix unzipping of software archives

### DIFF
--- a/build_functions.sh
+++ b/build_functions.sh
@@ -170,8 +170,7 @@ source_prepare() {
 		    *.zip)
 			unzip "${PACKAGE_FILE}"
 			cd "$SOURCE"
-			base_source="$(basename "${SOURCE}")"
-			mv */* .
+			rsync -ua --delete-after */ .
 			;;
 		    *)
 			log_error "NO RULE HOW TO EXTRACT '${PACKAGE_FILE}'";


### PR DESCRIPTION
Moving the unzipped files generated an error, in the current version this should be fixed (i.e. you can now give `.zip` URLs and Builder can properly unzip them + move the created files around).