### PR TITLE
Add option to silence interactive prompt when downloading only (`--get`)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ Options:
   -s or --silent     skip build if installation folder exists
   -f or --force      rebuild even if installation folder exists
   -g or --get        only download the package source files, adding --silent
-		     or -s results in dowloading the package files silently
+                     or -s results in dowloading the package files silently
 
   Builder  Copyright (C) 2020  Dennis Terhorst, Forschungszentrum Jülich GmbH/INM-6
   This program comes with ABSOLUTELY NO WARRANTY; for details type 'build help'.


### PR DESCRIPTION
Up to now, the `--get` options requires user interaction.
This is unhandy in the context of the Benchmarking Framework.
I add an option `build --get --silent` to suppress the user interaction in `--get` mode.