### PR TITLE
Add citation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ admins. Many aspects are inspired by
 [Portage](https://wiki.gentoo.org/wiki/Project:Portage), which is used by the
 [Gentoo](https://gentoo.org/) Linux distribution.
 
+When using Builder, **please cite as stated** on the [releases page](https://github.com/INM-6/Builder/releases).
 
 ## Installation
 


### PR DESCRIPTION
This change just adds a reference to how to cite releases. The specific form is then defined on the release page and can, for example, explicitly refer to the DOI.