### PR TITLE
Fix typo in MODULEPATH documentation

### DIFF
--- a/doc/Writing-new-modulefiles.md
+++ b/doc/Writing-new-modulefiles.md
@@ -8,7 +8,7 @@
   select a specific installed version of a software.
 
   If `modules` are installed, the only required change to write your own
-  modules is to have a `MODULESPATH` variable in your shell's environment.
+  modules is to have a `MODULEPATH` variable in your shell's environment.
 
      MODULEPATH=/path/to/your/modulefiles
 

--- a/doc/Writing-new-modulefiles.md
+++ b/doc/Writing-new-modulefiles.md
@@ -10,7 +10,7 @@
   If `modules` are installed, the only required change to write your own
   modules is to have a `MODULESPATH` variable in your shell's environment.
 
-     MODULESPATH=/path/to/your/modulefiles
+     MODULEPATH=/path/to/your/modulefiles
 
   Builder supports populating such a directory, if the plan-file is accompanied
   by a `.module` template.


### PR DESCRIPTION
The documentation for creating new module files has a typo, causing the module path to be wrong in user's setup.