### PR TITLE
Add plan files for builder itself

### DIFF
--- a/plans/Builder/0.1/default
+++ b/plans/Builder/0.1/default
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Builder – Compile scripts for local installs of software packages.
+# Copyright (C) 2020 Forschungszentrum Jülich GmbH, INM-6
+#
+# Builder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Builder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Builder.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+URL="https://github.com/INM-6/Builder/archive/v${VERSION}.tar.gz"
+MD5SUM="d00f46d1ed303ef0585d4f5877a0881b"
+SHA256SUM="c0c31bf219a655437064e61e6185b2e09dd40f961d695d0dbba59c9c58045985"
+
+build_prepare() {
+	log_status ">>> nothing to prepare"
+}
+build_package() {
+	log_status ">>> nothing to build"
+}
+build_install () {
+	log_status ">>> installing..."
+	mkdir -pv "${LOG}"
+	cd "${SOURCE}"
+	mkdir -pv "${TARGET}"
+	cp -rv build_functions.sh plans "${TARGET}" 2>&1 | tee "${LOG}/make-install.log"
+	cp -rv build.sh "${TARGET}/build" 2>&1 | tee "${LOG}/make-install.log"
+}

--- a/plans/Builder/0.1/default.module
+++ b/plans/Builder/0.1/default.module
@@ -1,0 +1,24 @@
+#%Module1.0#####################################################################
+#
+# ${AUTOMATIC_BUILD_WARNING}
+#
+set     INSTALLDIR      "${TARGET}"
+
+proc ModulesHelp { } {
+        puts stderr "
+   Collection of tools and scripts to install software on a system.
+
+   In contrast to usual packaging systems, the aim is to equally help users and
+   admins. Many aspects are inspired by Portage, which is used by the Gentoo
+   Linux distribution.
+
+   See https://github.com/INM-6/Builder
+"
+}
+
+module-whatis   "Bash testing framework (${VERSION})"
+
+conflict ${PACKAGE}
+${PREREQ_DEPENDS}
+
+prepend-path    PATH    \$INSTALLDIR


### PR DESCRIPTION
These changes add the release of Builder to the planfiles. By this it becomes possible to use a temporary Builder download to install Builder itself! (into configured locations, with module-files, etc..)
```
git clone https://github.com/INM-6/Builder
cd Builder
./build Builder
cd ..
rm -rf Builder
```