### PR TITLE
Fix PythonPath not set correctly across systems

### DIFF
--- a/plans/nest-simulator/2.20.0/default.module
+++ b/plans/nest-simulator/2.20.0/default.module
@@ -45,12 +45,12 @@ setenv          NEST_DATA_DIR           \$INSTALLDIR/share/nest
 setenv          NEST_DOC_DIR            \$INSTALLDIR/share/doc/nest
 
 # The path where NEST looks for user modules.
-setenv          NEST_MODULE_PATH        \$INSTALLDIR/lib64/nest
+setenv          NEST_MODULE_PATH        [glob -directory \$INSTALLDIR/ -type d lib*/nest/]
 
 # The path where the PyNEST bindings are installed.
 setenv          NEST_PYTHON_PREFIX      \$INSTALLDIR
 
-prepend-path    PYTHONPATH              \$INSTALLDIR/lib64/
+prepend-path    PYTHONPATH              [glob -directory \$INSTALLDIR/ -type d lib*/python*/site-packages/]
 prepend-path    PATH                    \$INSTALLDIR/bin
 #prepend-path    LD_LIBRARY_PATH  \$INSTALLDIR/lib64
 #prepend-path    MANPATH \$INSTALLDIR/man

--- a/plans/nest-simulator/2.20.1/default.module
+++ b/plans/nest-simulator/2.20.1/default.module
@@ -45,12 +45,12 @@ setenv          NEST_DATA_DIR           \$INSTALLDIR/share/nest
 setenv          NEST_DOC_DIR            \$INSTALLDIR/share/doc/nest
 
 # The path where NEST looks for user modules.
-setenv          NEST_MODULE_PATH        \$INSTALLDIR/lib64/nest
+setenv          NEST_MODULE_PATH        [glob -directory \$INSTALLDIR/ -type d lib*/nest/]
 
 # The path where the PyNEST bindings are installed.
 setenv          NEST_PYTHON_PREFIX      \$INSTALLDIR
 
-prepend-path    PYTHONPATH              \$INSTALLDIR/lib64/
+prepend-path    PYTHONPATH              [glob -directory \$INSTALLDIR/ -type d lib*/python*/site-packages/]
 prepend-path    PATH                    \$INSTALLDIR/bin
 #prepend-path    LD_LIBRARY_PATH  \$INSTALLDIR/lib64
 #prepend-path    MANPATH \$INSTALLDIR/man

--- a/plans/nest-simulator/3.0/default.module
+++ b/plans/nest-simulator/3.0/default.module
@@ -45,12 +45,12 @@ setenv          NEST_DATA_DIR           \$INSTALLDIR/share/nest
 setenv          NEST_DOC_DIR            \$INSTALLDIR/share/doc/nest
 
 # The path where NEST looks for user modules.
-setenv          NEST_MODULE_PATH        \$INSTALLDIR/lib64/nest
+setenv          NEST_MODULE_PATH        [glob -directory \$INSTALLDIR/ -type d lib*/nest/]
 
 # The path where the PyNEST bindings are installed.
 setenv          NEST_PYTHON_PREFIX      \$INSTALLDIR
 
-prepend-path    PYTHONPATH              \$INSTALLDIR/lib64/
+prepend-path    PYTHONPATH              [glob -directory \$INSTALLDIR/ -type d lib*/python*/site-packages/]
 prepend-path    PATH                    \$INSTALLDIR/bin
 #prepend-path    LD_LIBRARY_PATH  \$INSTALLDIR/lib64
 #prepend-path    MANPATH \$INSTALLDIR/man

--- a/plans/nest-simulator/3.1/default.module
+++ b/plans/nest-simulator/3.1/default.module
@@ -45,12 +45,12 @@ setenv          NEST_DATA_DIR           \$INSTALLDIR/share/nest
 setenv          NEST_DOC_DIR            \$INSTALLDIR/share/doc/nest
 
 # The path where NEST looks for user modules.
-setenv          NEST_MODULE_PATH        \$INSTALLDIR/lib64/nest
+setenv          NEST_MODULE_PATH        [glob -directory \$INSTALLDIR/ -type d lib*/nest/]
 
 # The path where the PyNEST bindings are installed.
 setenv          NEST_PYTHON_PREFIX      \$INSTALLDIR
 
-prepend-path    PYTHONPATH              \$INSTALLDIR/lib64/
+prepend-path    PYTHONPATH              [glob -directory \$INSTALLDIR/ -type d lib*/python*/site-packages/]
 prepend-path    PATH                    \$INSTALLDIR/bin
 #prepend-path    LD_LIBRARY_PATH  \$INSTALLDIR/lib64
 #prepend-path    MANPATH \$INSTALLDIR/man

--- a/plans/nest-simulator/common
+++ b/plans/nest-simulator/common
@@ -95,12 +95,6 @@ module_install () {
 			    #-e "s%\${\?PYTHON_SITEPKG}\?%$PYTHON_SITEPKG%g" \
 		fi
 
-                if [[ "${CMAKEFLAGS}" == *"python=ON"* ]]; then
-                        PYTHON_SITEPKG="$(python -c "import sysconfig; from pathlib import Path; print(Path(sysconfig.get_path('purelib')).relative_to(sysconfig.get_path('data')))")"
-                        PYTHON_SITEPKG=${PYTHON_SITEPKG#"lib/"}
-                        sed -i "s|.*PYTHONPATH.*|&$PYTHON_SITEPKG|" "$module_path"
-                fi
-
 		if ! echo "${MODULEPATH:-}" | grep "${MODULE_INSTALL_PATH}" >/dev/null; then
 			log_info ">>>"
 			log_info ">>> Info: MODULE_INSTALL_PATH is not in your MODULEPATH"

--- a/plans/nest-simulator/master/default.module
+++ b/plans/nest-simulator/master/default.module
@@ -45,12 +45,12 @@ setenv          NEST_DATA_DIR           \$INSTALLDIR/share/nest
 setenv          NEST_DOC_DIR            \$INSTALLDIR/share/doc/nest
 
 # The path where NEST looks for user modules.
-setenv          NEST_MODULE_PATH        \$INSTALLDIR/lib64/nest
+setenv          NEST_MODULE_PATH        [glob -directory \$INSTALLDIR/ -type d lib*/nest/]
 
 # The path where the PyNEST bindings are installed.
 setenv          NEST_PYTHON_PREFIX      \$INSTALLDIR
 
-prepend-path    PYTHONPATH              \$INSTALLDIR/lib64/
+prepend-path    PYTHONPATH              [glob -directory \$INSTALLDIR/ -type d lib*/python*/site-packages/]
 prepend-path    PATH                    \$INSTALLDIR/bin
 #prepend-path    LD_LIBRARY_PATH  \$INSTALLDIR/lib64
 #prepend-path    MANPATH \$INSTALLDIR/man


### PR DESCRIPTION
Fixed #53 and acts as a newer version of PR #55 incorporating the latest changes.  
I tested it on both environment modules (tcl) and lmod (lua) and surprisingly it works on both systems (even though I could not find any documentation on `glob` for lua).