### PR TITLE
Add BUILDER_CONFIG environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Optional Dependencies:
 
 You can install any software with Builder if a plan file is available. The
 default location where Builder looks for plan files is configured as
-`PLANFILE_PATH` in `~/.buildrc`. You will find many files in the scheme
-`<package>/<version>/<variant>`, where the `<variant>` uses `default` as its
-default value.
+`PLANFILE_PATH` in the [configuration](doc/Configuration.md). You will find
+many files in the scheme `<package>/<version>/<variant>`, where the `<variant>`
+uses `default` as its default value.
 
 To install a package replace `<package>` and `<version>` with an available
 build plan:

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -2,12 +2,12 @@
 
   Builder is designed to require only very minimal configuration. Upon its
   first build or when explicitly called with `build configure` a file
-  `.buildrc` is created if it does not exist yet. This file contains variables
-  that define various locations used in the build and install process.  When
-  the file is generated automatically Builder pre-fills some guessed defaults
-  that point to your home directory. While this quickly gets you started,
-  installing a lot of software into your `$HOME` is usually not a good idea and
-  you should set `$TARGET_PATH` to a better location.
+  `~/.buildrc` is created if it does not exist yet. This file contains
+  variables that define various locations used in the build and install
+  process.  When the file is generated automatically Builder pre-fills some
+  guessed defaults that point to your home directory. While this quickly gets
+  you started, installing a lot of software into your `$HOME` is usually not a
+  good idea and you should set `$TARGET_PATH` to a better location.
 
   The builder configuration defines variables of the build system itself.
   Mostly paths where Builder can put its work-space and where to put the

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -22,12 +22,13 @@
 
 ## `.buildrc` variables
 
-  Builder configuriation is automatically loaded from `$HOME/.buildrc`. If this
-  file does not exist, it will be created and the build will abort for you to
-  check the settings. The variables expected to be available after sourcing
-  `.buildrc` are described in the following table. The variables marked
-  "optional", if undefined, will be filled with appropriate default values by
-  builder for each build.
+  Builder configuriation is automatically loaded from `$HOME/.buildrc` (or the
+  file pointed to by the `$BUILDER_CONFIG` variable). If this file does not
+  exist, it will be created and the build will abort for you to check the
+  settings. The variables expected to be available after sourcing `.buildrc`
+  are described in the following table. The variables marked "optional", if
+  undefined, will be filled with appropriate default values by builder for each
+  build.
 
   Note that the expressions need not be constants, but are evaluated according
   to normal bash expansion rules (see man bash(1)). By this, you can

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -71,3 +71,20 @@ still available.
 
 After this you can install or load Builder and go on extending your deployment.
 
+
+### Multi-configuration Environments
+
+When using Builder in a multi-user or CI setup it is inconvenient to have the
+`.buildrc` loaded from the user-account home directory. To circumvent this the
+variable `$BUILDER_CONFIG` can be defined to override the default path. For
+example, suppose you keep your configuration in a repository
+`repo/builder.conf`. You can use any Builder installation available and point
+it to your current setup:
+
+```bash
+#cd repo   # wherever this is
+export BUILDER_CONFIG="${PWD}/builder.conf"
+```
+
+With this, `build` can be called from any location and will find the right
+config file.

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -48,10 +48,10 @@ We can however call Builder directly and start building env modules
     ./build.sh environment-modules
 
 This will build environment-modules as a normal package into your set install
-path (see `~/.buildrc`). Alternative implementations like 'lmod' may be built
-in a similar manner. Since many things depend on your choice here, you may want
-to look into the install instructions and probably manually change things here
-and there.
+path (see [configuration](Configuration.md)). Alternative implementations like
+'lmod' may be built in a similar manner. Since many things depend on your
+choice here, you may want to look into the install instructions and probably
+manually change things here and there.
 
     less ~/install/environment-modules/4.7.1/default/share/doc/INSTALL.txt
 

--- a/plans/nest-simulator/3.1/default
+++ b/plans/nest-simulator/3.1/default
@@ -25,4 +25,5 @@ SHA256SUM=5c11dd6b451c4c6bf93037bf29d5231c6c75a0e1a8863344f6fb9bb225f279ca
 
 CMAKEFLAGS+=" -Dwith-boost=ON -Dwith-python=ON -Dwith-mpi=ON -Dwith-detailed-timers=ON -Dwith-ltdl=OFF"
 
+# shellcheck source=../common
 source "$(dirname "${PLAN}")/../common"

--- a/plans/nest-simulator/3.1/default
+++ b/plans/nest-simulator/3.1/default
@@ -25,5 +25,5 @@ SHA256SUM=5c11dd6b451c4c6bf93037bf29d5231c6c75a0e1a8863344f6fb9bb225f279ca
 
 CMAKEFLAGS+=" -Dwith-boost=ON -Dwith-python=ON -Dwith-mpi=ON -Dwith-detailed-timers=ON -Dwith-ltdl=OFF"
 
-# shellcheck source=../common
+# shellcheck source=plans/nest-simulator/common
 source "$(dirname "${PLAN}")/../common"

--- a/plans/nest-simulator/common
+++ b/plans/nest-simulator/common
@@ -62,7 +62,7 @@ module_install () {
 		log_status ">>> installing module file to ${module_path}"
 		mkdir -pv "$(dirname "${module_path}")"
 		module="$(cat "${PLAN}.module")"
-		if version_gt $BASH_VERSION 4.4; then
+		if version_gt "${BASH_VERSION}" "4.4"; then
 			echo -e "${module@P}" >"${module_path}"
 		else
 			# this is a bad substitute for the power of the bash>4.4 notation.

--- a/plans/nest-simulator/master/default
+++ b/plans/nest-simulator/master/default
@@ -23,4 +23,5 @@ URL="https://github.com/nest/nest-simulator/archive/${VERSION}.tar.gz"
 
 CMAKEFLAGS+=" -Dwith-boost=ON -Dwith-python=ON -Dwith-mpi=ON -Dwith-detailed-timers=ON -Dwith-ltdl=OFF"
 
+# shellcheck source=../common
 source "$(dirname "${PLAN}")/../common"

--- a/plans/nest-simulator/master/default
+++ b/plans/nest-simulator/master/default
@@ -23,5 +23,5 @@ URL="https://github.com/nest/nest-simulator/archive/${VERSION}.tar.gz"
 
 CMAKEFLAGS+=" -Dwith-boost=ON -Dwith-python=ON -Dwith-mpi=ON -Dwith-detailed-timers=ON -Dwith-ltdl=OFF"
 
-# shellcheck source=../common
+# shellcheck source=plans/nest-simulator/common
 source "$(dirname "${PLAN}")/../common"


### PR DESCRIPTION
To make the configuration file select-able from the environment, this PR adds the `BUILDER_CONFIG` variable. For existing setups nothing should change, as the default value remains the same. It however enables users to keep different Builder configurations around (or in a repository) and point Builder to the one to use.
 
fixes #65 